### PR TITLE
Allow to use custom public paths for icons

### DIFF
--- a/design.config.js
+++ b/design.config.js
@@ -27,7 +27,7 @@ const config = {
 
   output: {
     path: path.join(__dirname, 'public/static/design'),
-    publicPath: '/static/design',
+    publicPath: process.env.ICONS_PUBLIC_PATH || '/static/design',
     icons: {
       files: 'icons',
       sprite: 'icons.svg',


### PR DESCRIPTION
Needed because reader is deployed on core.ac.uk/reader and all icons were resolved relative to core.ac.uk/static/design

@viktor-yakubiv do you have any better idea how to solve this issue? 