### PR TITLE
Decrease chunks count

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -49,6 +49,13 @@ const nextConfig = {
       return entries
     }
 
+    const splitChunks = config.optimization && config.optimization.splitChunks
+    if (splitChunks) {
+      const { cacheGroups } = splitChunks
+      if (cacheGroups.framework) cacheGroups.commons.name = 'framework'
+      if (cacheGroups.shared) cacheGroups.shared.name = 'framework'
+      if (cacheGroups.lib) cacheGroups.lib.name = 'framework'
+    }
     const { rules } = config.module
 
     // TODO: Remove once https://github.com/zeit/next.js/issues/10584 is solved and released


### PR DESCRIPTION
@viktor-yakubiv I decided to merge all vendors chunks together. The final chunk is obviously bigger but on the other hand browser needs to fire only one request instead of 4. If we had http2 there might be no need for this I assume. What do you think about this change?