### PR TITLE
Move Content-Security-Policy to configs

### DIFF
--- a/csp.config.js
+++ b/csp.config.js
@@ -1,0 +1,34 @@
+/*!
+ * Content-Security-Policy
+ */
+const SELF = "'self'"
+const PRODUCION = '*.core.ac.uk'
+
+const config = {
+  'default-src': [SELF, PRODUCION],
+  'script-src': [SELF, '*.google-analytics.com'],
+  // TODO: Remove 'unsafe-inline' when the Next.js' bug is resolved
+  // See more: https://github.com/vercel/next.js/issues/17445
+  'style-src': [SELF, "'unsafe-inline'"],
+  // Google Analytics may transport data via image:
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
+  'img-src': [SELF, PRODUCION, 'data:', '*.google-analytics.com'],
+  'connect-src': [SELF, PRODUCION, 'sentry.io', '*.google-analytics.com'],
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // Allow hot module replacement using inlined scripts and styles
+  config['script-src'].push("'unsafe-inline'", "'unsafe-eval'")
+  config['style-src'].push("'unsafe-inline'")
+
+  // Allow connection to the local hosts in development:
+  // - local API is running on a different port
+  // - `localhost` and `127.0.0.1` are not the same domain technically
+  config['connect-src'].push('localhost:* 127.0.0.1:*')
+}
+
+const policy = Object.entries(config)
+  .map(([directive, value]) => `${directive} ${value.join(' ')}`)
+  .join(';')
+
+module.exports = policy

--- a/csp.config.js
+++ b/csp.config.js
@@ -7,13 +7,26 @@ const PRODUCION = '*.core.ac.uk'
 const config = {
   'default-src': [SELF, PRODUCION],
   'script-src': [SELF, '*.google-analytics.com'],
-  // TODO: Remove 'unsafe-inline' when the Next.js' bug is resolved
-  // See more: https://github.com/vercel/next.js/issues/17445
-  'style-src': [SELF, "'unsafe-inline'"],
-  // Google Analytics may transport data via image:
-  // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
-  'img-src': [SELF, PRODUCION, 'data:', '*.google-analytics.com'],
-  'connect-src': [SELF, PRODUCION, 'sentry.io', '*.google-analytics.com'],
+  'style-src': [
+    SELF,
+    'fonts.googleapis.com',
+    'fonts.gstatic.com',
+    // TODO: Remove 'unsafe-inline' when the Next.js' bug is resolved
+    // See more: https://github.com/vercel/next.js/issues/17445
+    "'unsafe-inline'",
+  ],
+  'font-src': [SELF, 'fonts.googleapis.com', 'fonts.gstatic.com'],
+  'img-src': [
+    SELF,
+    PRODUCION,
+    'data:',
+    'blob:',
+    // Google Analytics may transport data via image:
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
+    '*.google-analytics.com',
+    'stats.g.doubleclick.net',
+  ],
+  'connect-src': ['*'],
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withWorkers = require('@zeit/next-workers')
 const withTM = require('next-transpile-modules')(['pdfjs-dist/lib'])
 const withSourceMaps = require('@zeit/next-source-maps')
 
+const csp = require
 const helpers = require('./utils/helpers')
 
 /** Build Target
@@ -22,6 +23,16 @@ const nextConfig = {
     BUILD_TARGET: process.env.BUILD_TARGET,
   },
   assetPrefix: helpers.getAssetPath('', process.env.BUILD_TARGET),
+
+  async headers() {
+    return [
+      {
+        source: '/:path(.*)',
+        headers: [{ key: 'Content-Security-Policy', value: csp }],
+      },
+    ]
+  },
+
   webpack: (config) => {
     const originalEntry = config.entry
     config.entry = async () => {

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const withWorkers = require('@zeit/next-workers')
 const withTM = require('next-transpile-modules')(['pdfjs-dist/lib'])
 const withSourceMaps = require('@zeit/next-source-maps')
 
-const csp = require
+const csp = require('./csp.config')
 const helpers = require('./utils/helpers')
 
 /** Build Target

--- a/pages/[pdfId].jsx
+++ b/pages/[pdfId].jsx
@@ -53,25 +53,6 @@ export async function getServerSideProps({ params: { pdfId }, res }) {
     value: Date.now() - startTime,
   })
 
-  res.setHeader(
-    'Content-Security-Policy',
-    [
-      // consider everything from these two domains as a safe
-      "default-src 'self' *.core.ac.uk core.ac.uk",
-      // in development there are attached inline scripts
-      // (probably from hot reload or some Next.JS magic)
-      // https://github.com/mozilla/pdf.js/issues/11036
-      `script-src 'self' *.google-analytics.com *.core.ac.uk core.ac.uk 'unsafe-eval' ${
-        process.env.NODE_ENV !== 'production' ? "'unsafe-inline'" : ''
-      }`,
-      "style-src 'self' https://fonts.googleapis.com/ https://fonts.gstatic.com/ 'unsafe-inline'",
-      `font-src 'self' data: https://fonts.googleapis.com/ https://fonts.gstatic.com/`,
-      // google analytics may transport info via image
-      // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
-      "img-src 'self' *.core.ac.uk core.ac.uk data: blob: *.google-analytics.com https://stats.g.doubleclick.net/",
-      'connect-src *',
-    ].join(';')
-  )
   res.statusCode = statusCode
 
   return {


### PR DESCRIPTION
1. Creates a separate configuration for CSP: `csp.config.js`
2. Removes `App.getIniaialProps()` to re-enable static optimisations
3. Adds the header via `next.config.js`' `header()` method

---

I was barely looking but I couldn't find CSP in the application.